### PR TITLE
chore: upgrade Spring Boot from 4.0.6 to 4.1.0

### DIFF
--- a/crud-spring/pom.xml
+++ b/crud-spring/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.6</version>
+		<version>4.1.0</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.loiane</groupId>


### PR DESCRIPTION
## Summary

Upgrades Spring Boot from 4.0.6 to 4.1.0 (GA release).

## Changes

- Updated `spring-boot-starter-parent` version in `crud-spring/pom.xml` from `4.0.6` to `4.1.0`

## Compatibility

The codebase was reviewed and uses no deprecated Spring Boot 4.0 APIs:
- All imports use `jakarta.*` (not `javax.*`)
- JPA, validation, and test APIs are all current
- No Derby database usage (removed in 4.1)
- No custom JPA bootstrap mode configuration

## What's new in Spring Boot 4.1

- First-class gRPC support
- Improved OpenTelemetry integration
- SSRF mitigation tooling for HTTP clients
- Lazy JDBC connection fetching
- `@RedisListener` auto-configuration